### PR TITLE
docs: fix template text and broken relative links

### DIFF
--- a/.github/DISCUSSIONS.md
+++ b/.github/DISCUSSIONS.md
@@ -65,8 +65,8 @@ Format code properly, use clear titles, and include context.
 
 ## Quick Links
 
-- [Documentation](README.md)
+- [Documentation](../README.md)
 - [Bug Reports](../../issues)
-- [Contributing Guide](CONTRIBUTING.md)
+- [Contributing Guide](../CONTRIBUTING.md)
 
 Let's build an amazing community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Thank you for contributing to this extension template.
+Thank you for contributing to this extension.
 
 Please fork, add features on a branch, run `npm run build` and open a PR.


### PR DESCRIPTION
## Summary
- Fixed CONTRIBUTING.md template text ("this extension template" → "this extension")
- Fixed broken relative links in .github/DISCUSSIONS.md (links from .github/ subfolder now correctly point to root README.md and CONTRIBUTING.md)

Resolves part of winccoa-tools-pack/.github#73
